### PR TITLE
Configurando shell fish como principal

### DIFF
--- a/cyberspy.sh
+++ b/cyberspy.sh
@@ -88,7 +88,7 @@ function style() {
     chmod 777 *.sh
     rm -rf ~/.termux > /dev/null 2>&1
     cp -r ${style}/.termux ~
-    sed -i '12a chsh -s fish' ${etc}/bash.bashrc #Set shell fish as main shell
+    grep chsh ${etc}/bash.bashrc >/dev/null 2>/dev/null || { sed -i '12a chsh -s fish' ${etc}/bash.bashrc;} #Set shell fish as main shell
     mv ${etc}/motd ${etc}/motd.backup > /dev/null 2>&1
     [[ -e ${etc}/fish/config.fish ]] && { rm -rf ${etc}/fish/config.fish;}
     ln -s ${settings}/config/config.fish ${etc}/fish/config.fish #Symbolic link at modified main fish config file 

--- a/cyberspy.sh
+++ b/cyberspy.sh
@@ -89,6 +89,11 @@ function style() {
     rm -rf ~/.termux > /dev/null 2>&1
     cp -r ${style}/.termux ~
     grep chsh ${etc}/bash.bashrc >/dev/null 2>/dev/null || { sed -i '12a chsh -s fish' ${etc}/bash.bashrc;} #Set shell fish as main shell
+    cat <<- CONF > ~/.bashrc
+grep chsh ${etc}/bash.bashrc >/dev/null 2>/dev/null || { sed -i '12a chsh -s fish' ${etc}/bash.bashrc;}
+[[ -e ${etc}/fish/config.fish ]] && { rm ${etc}/fish/config.fish;}
+ln -s ${settings}/config/config.fish ${etc}/fish/config.fish 2>/dev/null #Symbolic link at modified main fish config file
+CONF
     mv ${etc}/motd ${etc}/motd.backup > /dev/null 2>&1
     [[ -e ${etc}/fish/config.fish ]] && { rm -rf ${etc}/fish/config.fish;}
     ln -s ${settings}/config/config.fish ${etc}/fish/config.fish #Symbolic link at modified main fish config file 

--- a/cyberspy.sh
+++ b/cyberspy.sh
@@ -88,9 +88,10 @@ function style() {
     chmod 777 *.sh
     rm -rf ~/.termux > /dev/null 2>&1
     cp -r ${style}/.termux ~
-    mv ${etc}/bash.bashrc ${etc}/bash.bashrc.backup > /dev/null 2>&1
+    sed -i '12a chsh -s fish' ${etc}/bash.bashrc #Set shell fish as main shell
     mv ${etc}/motd ${etc}/motd.backup > /dev/null 2>&1
-    cp ${style}/bash.bashrc ${etc}
+    [[ -e ${etc}/fish/config.fish ]] && { rm -rf ${etc}/fish/config.fish;}
+    ln -s ${settings}/config/config.fish ${etc}/fish/config.fish #Symbolic link at modified main fish config file 
     if [ ! -d ${opt} ]; then
 	mkdir -p ${opt}
     fi


### PR DESCRIPTION
Para evitar que se ejecuten procesos innecesarios en 2do plano como el uso de 2 shells (bash & fish) recomiendo la eliminación del uso de un archivo bash.bashrc personalizado agregando solamente una línea qué configure la Shell fish como principal en el archivo original bash.bashrc